### PR TITLE
Run Travis CI on multiple OS including Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,12 @@ rust:
   - beta
   - nightly
 cache: cargo
+os:
+  - linux
+  - osx
+  - windows
+before_install:
+  - |
+      if [ "$TRAVIS_OS_NAME" == "windows" ]; then
+        /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/VC/Tools/MSVC/14.15.26726/bin/HostX64/vcvarsall.bat x86
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ os:
   - linux
   - osx
   - windows
-before_install:
-  - |
-      if [ "$TRAVIS_OS_NAME" == "windows" ]; then
-        /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/VC/Tools/MSVC/14.15.26726/bin/HostX64/vcvarsall.bat x86
-      fi
+matrix:
+  allow_failures:
+    - os: windows


### PR DESCRIPTION
Travis builds on linux by default so this change effectively adds just:

- osx
- windows

Travis CI Windows support is still early-access and it fails to build because of VS 2017 in the build image that can't compile the winapi crate. See:

https://travis-ci.community/t/rust-error-could-not-compile-winapi/268/3

Attempted to run `vcvarsall.bat` in the `before_install` step as a workaround but I couldn't find the executable. For now, I just configured Travis to allow Windows to fail.
